### PR TITLE
Update repository URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "composer",
-      "url": "https://languages.koodimonni.fi"
+      "url": "https://wp-languages.github.io"
     },
     {
       "type": "package",


### PR DESCRIPTION
The URL for the language pack by Koodimonni now reside on a new URL. I have updated the repository URL within the `composer.json` file to reflect this.